### PR TITLE
Update to latest Livy release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ENV SPARK_HOME /opt/spark
 ENV SPARK_CONF_DIR /opt/livy/conf
 ENV LIVY_LOG_DIR /var/log/livy
 RUN mkdir $LIVY_LOG_DIR
+RUN apk add --update python2 python3 && rm -rf /var/cache/apk/* && \
+    pip3 install --no-cache-dir pyspark
 ADD url ./
 RUN wget `cat url` -O livy.zip && unzip livy.zip && rm livy.zip && mv livy* livy
 ADD defaults/* defaults/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elek/spark-base:1.6.2
+FROM elek/spark-base
 ENV HADOOP_CONF_DIR /opt/livy/conf
 ENV CONF_DIR /opt/livy/conf
 ENV SPARK_HOME /opt/spark

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ ENV HADOOP_CONF_DIR /opt/livy/conf
 ENV CONF_DIR /opt/livy/conf
 ENV SPARK_HOME /opt/spark
 ENV SPARK_CONF_DIR /opt/livy/conf
+ENV LIVY_LOG_DIR /var/log/livy
+RUN mkdir $LIVY_LOG_DIR
 ADD url ./
-RUN wget `cat url` -O livy.zip && unzip livy.zip && rm livy.zip && mv livy* livy 
+RUN wget `cat url` -O livy.zip && unzip livy.zip && rm livy.zip && mv livy* livy
 ADD defaults/* defaults/
 CMD ["/opt/livy/bin/livy-server"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ENV SPARK_HOME /opt/spark
 ENV SPARK_CONF_DIR /opt/livy/conf
 ENV LIVY_LOG_DIR /var/log/livy
 RUN mkdir $LIVY_LOG_DIR
-RUN apk add --update python2 python3 && rm -rf /var/cache/apk/* && \
-    pip3 install --no-cache-dir pyspark
+RUN apk add --update python3 R && rm -rf /var/cache/apk/*
+ENV PYSPARK_PYTHON python3
 ADD url ./
 RUN wget `cat url` -O livy.zip && unzip livy.zip && rm livy.zip && mv livy* livy
 ADD defaults/* defaults/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,3 @@ If there is plain version tag without prefix it is synchronized with the version
 It there is a prefix (eg. HDP) it includes a specific version from a specific distribution.
 
 As the configuration loading in the base image is constantly evolving even the tags of older releases may be refreshed over the time.
-
-**As livy currently only supports spark 1.6 the latest version is based on the latest stable 1.6.**
-

--- a/url
+++ b/url
@@ -1,1 +1,1 @@
-http://archive.cloudera.com/beta/livy/livy-server-0.2.0.zip
+http://apache.mirror.anlx.net/incubator/livy/0.5.0-incubating/livy-0.5.0-incubating-bin.zip


### PR DESCRIPTION
The latest Livy release supports Spark 2. This PR updates to that latest release, unpins the Spark version, and additionally installs Python and PySpark onto the image to enable Python sessions.

Please make use of any or all of these changes as you see fit.

Thanks for the good work! I am finding this really useful for a development environment for a Python Livy client (https://github.com/acroz/pylivy).